### PR TITLE
Create timestampFormat property and set created_at and updated_at attributes with it

### DIFF
--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -69,6 +69,11 @@ abstract class Mapper
     protected $hasTimestamps = true;
 
     /**
+     * @var string
+     */
+    protected $timestampFormat = 'Y-m-d H:i:s';
+
+    /**
      * @var boolean
      */
     protected $isAutoIncrementing = true;
@@ -491,7 +496,7 @@ abstract class Mapper
                     if ($this->hasTimestamps === true) {
                         $attributes = \Illuminate\Support\Arr::except($attributes, [self::UPDATED_AT, self::CREATED_AT]);
                         $now = new DateTime('now', new \DateTimeZone(static::DEFAULT_TIME_ZONE));
-                        $attributes[static::UPDATED_AT] = $now;
+                        $attributes[static::UPDATED_AT] = $now->format($this->timestampFormat);
 
                         if (method_exists($this, 'setUpdatedAtTimestampOnEntity')) {
                             $this->setUpdatedAtTimestampOnEntity($entity, $now);
@@ -516,8 +521,8 @@ abstract class Mapper
 
                 if ($this->hasTimestamps === true) {
                     $now = new DateTime('now', new \DateTimeZone(static::DEFAULT_TIME_ZONE));
-                    $attributes[static::CREATED_AT] = $now;
-                    $attributes[static::UPDATED_AT] = $now;
+                    $attributes[static::CREATED_AT] = $now->format($this->timestampFormat);
+                    $attributes[static::UPDATED_AT] = $now->format($this->timestampFormat);
 
                     if (method_exists($this, 'setCreatedAtTimestampOnEntity')) {
                         $this->setCreatedAtTimestampOnEntity($entity, $now);


### PR DESCRIPTION
This adds an overridable timestampFormat property to the mapper and uses it when setting the created_at and updated_at properties on entities.

We may also need to do this in the calls to Mappers\Mapper->setCreatedAtTimestampOnEntity() and Mappers\Mapper->setUpdatedAtTimestampOnEntity(), but this will require changing the definitions of those methods to accept string|DateTime values for the $now argument instead of just DateTime.