### PR TITLE
Update Mapper.php

### DIFF
--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -500,7 +500,7 @@ abstract class Mapper
             $this->getConnection()
                 ->table($this->getTable())
                 ->where($this->getKeyName(), $identifier)
-                ->update([$this->getQualifiedDeletedAtColumn() => new DateTime]);
+                ->update([$this->getQualifiedDeletedAtColumn() => $this->currentTime()]);
         } else {
             $this->getConnection()
                 ->table($this->getTable())

--- a/tests/Integration/MapperTest.php
+++ b/tests/Integration/MapperTest.php
@@ -703,6 +703,23 @@ class MapperTest extends TestCase
     }
 
     /** @test */
+    public function it_can_soft_delete_entities_with_current_time()
+    {
+        // given
+        $this->buildFixtures();
+        $mapper = Holloway::instance()->getMapper(Pup::class);    // The pup mapper fixture uses soft deletes
+        $tobi = $mapper->find(1);
+
+        // when
+        $mapper->remove($tobi);
+
+        // then
+        $deletedAt = $mapper->withTrashed()->find(1)->deleted_at;
+        $this->assertNotNull($deletedAt);
+        $this->assertGreaterThanOrEqual((string) $deletedAt, (string) CarbonImmutable::now());
+    }
+
+    /** @test */
     function it_doesnt_load_soft_deleted_entities_when_querying_relationships()
     {
         // given


### PR DESCRIPTION
This change makes the soft delete (removeEntity) use the `currentTime()` method instead of hard coding `new DateTime()`. 

This change will allow us to override in our tests where we use Chronos::setTestNow().